### PR TITLE
Update to Akka 1.3.8

### DIFF
--- a/CurryOn.Akka.Persistence.Common/CurryOn.Akka.Persistence.Common.fsproj
+++ b/CurryOn.Akka.Persistence.Common/CurryOn.Akka.Persistence.Common.fsproj
@@ -62,22 +62,22 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Akka">
-      <HintPath>..\packages\Akka.1.3.4\lib\net45\Akka.dll</HintPath>
+      <HintPath>..\packages\Akka.1.3.8\lib\net45\Akka.dll</HintPath>
     </Reference>
     <Reference Include="Akka.FSharp">
-      <HintPath>..\packages\Akka.FSharp.1.2.3\lib\net45\Akka.FSharp.dll</HintPath>
+      <HintPath>..\packages\Akka.FSharp.1.3.8\lib\net45\Akka.FSharp.dll</HintPath>
     </Reference>
     <Reference Include="Akka.Persistence">
-      <HintPath>..\packages\Akka.Persistence.1.2.3.43-beta\lib\net45\Akka.Persistence.dll</HintPath>
+      <HintPath>..\packages\Akka.Persistence.1.3.8\lib\net45\Akka.Persistence.dll</HintPath>
     </Reference>
     <Reference Include="Akka.Persistence.Query">
-      <HintPath>..\packages\Akka.Persistence.Query.1.2.3.43-beta\lib\net45\Akka.Persistence.Query.dll</HintPath>
+      <HintPath>..\packages\Akka.Persistence.Query.1.3.8\lib\net45\Akka.Persistence.Query.dll</HintPath>
     </Reference>
     <Reference Include="Akka.Streams">
-      <HintPath>..\packages\Akka.Streams.1.2.3\lib\net45\Akka.Streams.dll</HintPath>
+      <HintPath>..\packages\Akka.Streams.1.3.8\lib\net45\Akka.Streams.dll</HintPath>
     </Reference>
     <Reference Include="FSharp.Core">
-      <HintPath>..\packages\FSharp.Core.4.1.17\lib\net45\FSharp.Core.dll</HintPath>
+      <HintPath>..\packages\FSharp.Core.4.2.3\lib\net45\FSharp.Core.dll</HintPath>
     </Reference>
     <Reference Include="FSharp.PowerPack">
       <HintPath>..\packages\FSPowerPack.Core.Community.3.0.0.0\Lib\Net40\FSharp.PowerPack.dll</HintPath>
@@ -85,11 +85,14 @@
     <Reference Include="FSharp.PowerPack.Linq">
       <HintPath>..\packages\FSPowerPack.Linq.Community.3.0.0.0\Lib\Net40\FSharp.PowerPack.Linq.dll</HintPath>
     </Reference>
+    <Reference Include="FSharp.Quotations.Evaluator">
+      <HintPath>..\packages\FSharp.Quotations.Evaluator.1.1.2\lib\net45\FSharp.Quotations.Evaluator.dll</HintPath>
+    </Reference>
     <Reference Include="FsPickler">
-      <HintPath>..\packages\FsPickler.3.2.0\lib\net45\FsPickler.dll</HintPath>
+      <HintPath>..\packages\FsPickler.5.2\lib\net45\FsPickler.dll</HintPath>
     </Reference>
     <Reference Include="FsPickler.Json">
-      <HintPath>..\packages\FsPickler.Json.3.2.0\lib\net45\FsPickler.Json.dll</HintPath>
+      <HintPath>..\packages\FsPickler.Json.5.0\lib\net45\FsPickler.Json.dll</HintPath>
     </Reference>
     <Reference Include="Google.Protobuf">
       <HintPath>..\packages\Google.Protobuf.3.3.0\lib\net45\Google.Protobuf.dll</HintPath>
@@ -116,7 +119,8 @@
     <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ValueTuple">
-      <HintPath>..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/CurryOn.Akka.Persistence.Common/Serialization.fs
+++ b/CurryOn.Akka.Persistence.Common/Serialization.fs
@@ -10,7 +10,7 @@ open System.Reflection
 
 module Serialization =
     let private BinarySerializer = BinarySerializer()
-    let private JsonSerializer = JsonSerializer(indent = true)
+    let private JsonSerializer = JsonSerializer(indent = true, omitHeader = true)
 
     let toBinary any =
         use stream = new MemoryStream()

--- a/CurryOn.Akka.Persistence.Common/packages.config
+++ b/CurryOn.Akka.Persistence.Common/packages.config
@@ -1,13 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Akka" version="1.3.4" targetFramework="net46" />
-  <package id="Akka.FSharp" version="1.2.3" targetFramework="net46" />
-  <package id="Akka.Persistence" version="1.2.3.43-beta" targetFramework="net46" />
-  <package id="Akka.Persistence.Query" version="1.2.3.43-beta" targetFramework="net46" />
-  <package id="Akka.Streams" version="1.2.3" targetFramework="net46" />
-  <package id="FSharp.Core" version="4.1.17" targetFramework="net46" />
-  <package id="FsPickler" version="3.2.0" targetFramework="net46" />
-  <package id="FsPickler.Json" version="3.2.0" targetFramework="net46" />
+  <package id="Akka" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.FSharp" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.Persistence" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.Persistence.Query" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.Streams" version="1.3.8" targetFramework="net46" />
+  <package id="FSharp.Core" version="4.2.3" targetFramework="net46" />
+  <package id="FSharp.Quotations.Evaluator" version="1.1.2" targetFramework="net46" />
+  <package id="FsPickler" version="5.2" targetFramework="net46" />
+  <package id="FsPickler.Json" version="5.0" targetFramework="net46" />
   <package id="FSPowerPack.Core.Community" version="3.0.0.0" targetFramework="net46" />
   <package id="FSPowerPack.Linq.Community" version="3.0.0.0" targetFramework="net46" />
   <package id="Google.Protobuf" version="3.3.0" targetFramework="net46" />
@@ -15,5 +16,5 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
   <package id="Reactive.Streams" version="1.0.2" targetFramework="net46" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net46" />
-  <package id="System.ValueTuple" version="4.3.0" targetFramework="net46" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net46" />
 </packages>

--- a/CurryOn.Akka.Persistence.Elasticsearch/CurryOn.Akka.Persistence.Elasticsearch.fsproj
+++ b/CurryOn.Akka.Persistence.Elasticsearch/CurryOn.Akka.Persistence.Elasticsearch.fsproj
@@ -64,28 +64,28 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Akka">
-      <HintPath>..\packages\Akka.1.2.3\lib\net45\Akka.dll</HintPath>
+      <HintPath>..\packages\Akka.1.3.8\lib\net45\Akka.dll</HintPath>
     </Reference>
     <Reference Include="Akka.FSharp">
-      <HintPath>..\packages\Akka.FSharp.1.2.3\lib\net45\Akka.FSharp.dll</HintPath>
+      <HintPath>..\packages\Akka.FSharp.1.3.8\lib\net45\Akka.FSharp.dll</HintPath>
     </Reference>
     <Reference Include="Akka.Persistence">
-      <HintPath>..\packages\Akka.Persistence.1.2.3.43-beta\lib\net45\Akka.Persistence.dll</HintPath>
+      <HintPath>..\packages\Akka.Persistence.1.3.8\lib\net45\Akka.Persistence.dll</HintPath>
     </Reference>
     <Reference Include="Akka.Persistence.FSharp">
-      <HintPath>..\packages\Akka.Persistence.FSharp.1.2.3.43-beta\lib\net45\Akka.Persistence.FSharp.dll</HintPath>
+      <HintPath>..\packages\Akka.Persistence.FSharp.1.3.8\lib\net45\Akka.Persistence.FSharp.dll</HintPath>
     </Reference>
     <Reference Include="Akka.Persistence.Query">
-      <HintPath>..\packages\Akka.Persistence.Query.1.2.3.43-beta\lib\net45\Akka.Persistence.Query.dll</HintPath>
+      <HintPath>..\packages\Akka.Persistence.Query.1.3.8\lib\net45\Akka.Persistence.Query.dll</HintPath>
     </Reference>
     <Reference Include="Akka.Streams">
-      <HintPath>..\packages\Akka.Streams.1.2.3\lib\net45\Akka.Streams.dll</HintPath>
+      <HintPath>..\packages\Akka.Streams.1.3.8\lib\net45\Akka.Streams.dll</HintPath>
     </Reference>
     <Reference Include="Elasticsearch.Net">
       <HintPath>..\packages\Elasticsearch.Net.5.6.0\lib\net46\Elasticsearch.Net.dll</HintPath>
     </Reference>
     <Reference Include="FSharp.Core">
-      <HintPath>..\packages\FSharp.Core.4.1.17\lib\net45\FSharp.Core.dll</HintPath>
+      <HintPath>..\packages\FSharp.Core.4.2.3\lib\net45\FSharp.Core.dll</HintPath>
     </Reference>
     <Reference Include="FSharp.PowerPack">
       <HintPath>..\packages\FSPowerPack.Core.Community.3.0.0.0\Lib\Net40\FSharp.PowerPack.dll</HintPath>
@@ -93,12 +93,17 @@
     <Reference Include="FSharp.PowerPack.Linq">
       <HintPath>..\packages\FSPowerPack.Linq.Community.3.0.0.0\Lib\Net40\FSharp.PowerPack.Linq.dll</HintPath>
     </Reference>
-    <Reference Include="FsPickler, Version=3.2.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\FsPickler.3.2.0\lib\net45\FsPickler.dll</HintPath>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="FSharp.Quotations.Evaluator">
+      <HintPath>..\packages\FSharp.Quotations.Evaluator.1.1.2\lib\net45\FSharp.Quotations.Evaluator.dll</HintPath>
+    </Reference>
+    <Reference Include="FsPickler">
+      <HintPath>..\packages\FsPickler.5.2\lib\net45\FsPickler.dll</HintPath>
     </Reference>
     <Reference Include="FsPickler.Json">
-      <HintPath>..\packages\FsPickler.Json.3.2.0\lib\net45\FsPickler.Json.dll</HintPath>
+      <HintPath>..\packages\FsPickler.Json.5.0\lib\net45\FsPickler.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Google.Protobuf">
+      <HintPath>..\packages\Google.Protobuf.3.3.0\lib\net45\Google.Protobuf.dll</HintPath>
     </Reference>
     <Reference Include="Google.ProtocolBuffers">
       <HintPath>..\packages\Google.ProtocolBuffers.2.4.1.555\lib\net40\Google.ProtocolBuffers.dll</HintPath>
@@ -120,11 +125,13 @@
     <Reference Include="System.Collections.Immutable">
       <HintPath>..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ValueTuple">
-      <HintPath>..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/CurryOn.Akka.Persistence.Elasticsearch/Query.fs
+++ b/CurryOn.Akka.Persistence.Elasticsearch/Query.fs
@@ -17,7 +17,7 @@ module internal PersistenceQuery =
         | None -> UnboundedLower
 
     let inline hitToEventEnvelope (hit: Hit<PersistedEvent>) =
-        EventEnvelope(hit.Id.ToInt(), hit.Document.PersistenceId, hit.Document.SequenceNumber, hit.Document.Event |> Serialization.parseJson<obj>)
+        EventEnvelope(Offset.Sequence(hit.Id.ToInt()), hit.Document.PersistenceId, hit.Document.SequenceNumber, hit.Document.Event |> Serialization.parseJson<obj>)
 
     let inline processHits (subscriber: ISubscriber<EventEnvelope>) (search: SearchResult<PersistedEvent>)  =
         search.Results.Hits

--- a/CurryOn.Akka.Persistence.Elasticsearch/packages.config
+++ b/CurryOn.Akka.Persistence.Elasticsearch/packages.config
@@ -1,21 +1,23 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Akka" version="1.2.3" targetFramework="net46" />
-  <package id="Akka.FSharp" version="1.2.3" targetFramework="net46" />
-  <package id="Akka.Persistence" version="1.2.3.43-beta" targetFramework="net46" />
-  <package id="Akka.Persistence.FSharp" version="1.2.3.43-beta" targetFramework="net46" />
-  <package id="Akka.Persistence.Query" version="1.2.3.43-beta" targetFramework="net46" />
-  <package id="Akka.Streams" version="1.2.3" targetFramework="net46" />
+  <package id="Akka" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.FSharp" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.Persistence" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.Persistence.FSharp" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.Persistence.Query" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.Streams" version="1.3.8" targetFramework="net46" />
   <package id="Elasticsearch.Net" version="5.6.0" targetFramework="net46" />
-  <package id="FSharp.Core" version="4.1.17" targetFramework="net46" />
-  <package id="FsPickler" version="3.2.0" targetFramework="net46" />
-  <package id="FsPickler.Json" version="3.2.0" targetFramework="net46" />
+  <package id="FSharp.Core" version="4.2.3" targetFramework="net46" />
+  <package id="FSharp.Quotations.Evaluator" version="1.1.2" targetFramework="net46" />
+  <package id="FsPickler" version="5.2" targetFramework="net46" />
+  <package id="FsPickler.Json" version="5.0" targetFramework="net46" />
   <package id="FSPowerPack.Core.Community" version="3.0.0.0" targetFramework="net46" />
   <package id="FSPowerPack.Linq.Community" version="3.0.0.0" targetFramework="net46" />
+  <package id="Google.Protobuf" version="3.3.0" targetFramework="net46" />
   <package id="Google.ProtocolBuffers" version="2.4.1.555" targetFramework="net46" />
   <package id="NEST" version="5.6.0" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="10.0.1" targetFramework="net46" />
   <package id="Reactive.Streams" version="1.0.2" targetFramework="net46" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net46" />
-  <package id="System.ValueTuple" version="4.3.0" targetFramework="net46" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net46" />
 </packages>

--- a/CurryOn.Akka.Persistence.EventStore/CurryOn.Akka.Persistence.EventStore.fsproj
+++ b/CurryOn.Akka.Persistence.EventStore/CurryOn.Akka.Persistence.EventStore.fsproj
@@ -63,34 +63,43 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Akka">
-      <HintPath>..\packages\Akka.1.2.3\lib\net45\Akka.dll</HintPath>
+      <HintPath>..\packages\Akka.1.3.8\lib\net45\Akka.dll</HintPath>
+    </Reference>
+    <Reference Include="Akka.FSharp">
+      <HintPath>..\packages\Akka.FSharp.1.3.8\lib\net45\Akka.FSharp.dll</HintPath>
     </Reference>
     <Reference Include="Akka.Persistence">
-      <HintPath>..\packages\Akka.Persistence.1.2.3.43-beta\lib\net45\Akka.Persistence.dll</HintPath>
+      <HintPath>..\packages\Akka.Persistence.1.3.8\lib\net45\Akka.Persistence.dll</HintPath>
     </Reference>
     <Reference Include="Akka.Persistence.FSharp">
-      <HintPath>..\packages\Akka.Persistence.FSharp.1.2.3.43-beta\lib\net45\Akka.Persistence.FSharp.dll</HintPath>
+      <HintPath>..\packages\Akka.Persistence.FSharp.1.3.8\lib\net45\Akka.Persistence.FSharp.dll</HintPath>
     </Reference>
     <Reference Include="Akka.Persistence.Query">
-      <HintPath>..\packages\Akka.Persistence.Query.1.2.3.43-beta\lib\net45\Akka.Persistence.Query.dll</HintPath>
+      <HintPath>..\packages\Akka.Persistence.Query.1.3.8\lib\net45\Akka.Persistence.Query.dll</HintPath>
     </Reference>
     <Reference Include="Akka.Serialization.Hyperion">
-      <HintPath>..\packages\Akka.Serialization.Hyperion.1.2.3.43-beta\lib\net45\Akka.Serialization.Hyperion.dll</HintPath>
+      <HintPath>..\packages\Akka.Serialization.Hyperion.1.3.8-beta66\lib\net45\Akka.Serialization.Hyperion.dll</HintPath>
     </Reference>
     <Reference Include="Akka.Streams">
-      <HintPath>..\packages\Akka.Streams.1.2.3\lib\net45\Akka.Streams.dll</HintPath>
+      <HintPath>..\packages\Akka.Streams.1.3.8\lib\net45\Akka.Streams.dll</HintPath>
     </Reference>
     <Reference Include="EventStore.ClientAPI">
       <HintPath>..\packages\EventStore.Client.4.0.3\lib\net40\EventStore.ClientAPI.dll</HintPath>
     </Reference>
     <Reference Include="FSharp.Core">
-      <HintPath>..\packages\FSharp.Core.4.1.17\lib\net45\FSharp.Core.dll</HintPath>
+      <HintPath>..\packages\FSharp.Core.4.2.3\lib\net45\FSharp.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="FSharp.Quotations.Evaluator">
+      <HintPath>..\packages\FSharp.Quotations.Evaluator.1.1.2\lib\net45\FSharp.Quotations.Evaluator.dll</HintPath>
     </Reference>
     <Reference Include="FsPickler">
-      <HintPath>..\packages\FsPickler.3.2.0\lib\net45\FsPickler.dll</HintPath>
+      <HintPath>..\packages\FsPickler.5.2\lib\net45\FsPickler.dll</HintPath>
     </Reference>
     <Reference Include="FsPickler.Json">
-      <HintPath>..\packages\FsPickler.Json.3.2.0\lib\net45\FsPickler.Json.dll</HintPath>
+      <HintPath>..\packages\FsPickler.Json.5.0\lib\net45\FsPickler.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Google.Protobuf">
+      <HintPath>..\packages\Google.Protobuf.3.3.0\lib\net45\Google.Protobuf.dll</HintPath>
     </Reference>
     <Reference Include="Google.ProtocolBuffers">
       <HintPath>..\packages\Google.ProtocolBuffers.2.4.1.555\lib\net40\Google.ProtocolBuffers.dll</HintPath>
@@ -99,8 +108,9 @@
       <HintPath>..\packages\Google.ProtocolBuffers.2.4.1.555\lib\net40\Google.ProtocolBuffers.Serialization.dll</HintPath>
     </Reference>
     <Reference Include="Hyperion">
-      <HintPath>..\packages\Hyperion.0.9.2\lib\net45\Hyperion.dll</HintPath>
+      <HintPath>..\packages\Hyperion.0.9.8\lib\net45\Hyperion.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualStudio.Threading">
       <HintPath>..\packages\Microsoft.VisualStudio.Threading.15.4.4\lib\net45\Microsoft.VisualStudio.Threading.dll</HintPath>
     </Reference>
@@ -119,11 +129,13 @@
     <Reference Include="System.Collections.Immutable">
       <HintPath>..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ValueTuple">
-      <HintPath>..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/CurryOn.Akka.Persistence.EventStore/WriteJournal.fs
+++ b/CurryOn.Akka.Persistence.EventStore/WriteJournal.fs
@@ -159,7 +159,7 @@ module EventJournal =
                 operation {
                     let stopped = AsyncManualResetEvent(initialState = false)
                     let start = Math.Max(0L, first - 2L)
-                    let eventsToRead = Math.Min(last - start + 1L, max)
+                    let eventsToRead = Math.Min(last - start + 1L, (int64) readBatchSize)
 
                     let rec getEvents offset eventsSoFar =
                         task {

--- a/CurryOn.Akka.Persistence.EventStore/packages.config
+++ b/CurryOn.Akka.Persistence.EventStore/packages.config
@@ -1,21 +1,24 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Akka" version="1.2.3" targetFramework="net46" />
-  <package id="Akka.Persistence" version="1.2.3.43-beta" targetFramework="net46" />
-  <package id="Akka.Persistence.FSharp" version="1.2.3.43-beta" targetFramework="net46" />
-  <package id="Akka.Persistence.Query" version="1.2.3.43-beta" targetFramework="net46" />
-  <package id="Akka.Serialization.Hyperion" version="1.2.3.43-beta" targetFramework="net46" />
-  <package id="Akka.Streams" version="1.2.3" targetFramework="net46" />
+  <package id="Akka" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.FSharp" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.Persistence" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.Persistence.FSharp" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.Persistence.Query" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.Serialization.Hyperion" version="1.3.8-beta66" targetFramework="net46" />
+  <package id="Akka.Streams" version="1.3.8" targetFramework="net46" />
   <package id="EventStore.Client" version="4.0.3" targetFramework="net46" />
-  <package id="FSharp.Core" version="4.1.17" targetFramework="net46" />
-  <package id="FsPickler" version="3.2.0" targetFramework="net46" />
-  <package id="FsPickler.Json" version="3.2.0" targetFramework="net46" />
+  <package id="FSharp.Core" version="4.2.3" targetFramework="net46" />
+  <package id="FSharp.Quotations.Evaluator" version="1.1.2" targetFramework="net46" />
+  <package id="FsPickler" version="5.2" targetFramework="net46" />
+  <package id="FsPickler.Json" version="5.0" targetFramework="net46" />
+  <package id="Google.Protobuf" version="3.3.0" targetFramework="net46" />
   <package id="Google.ProtocolBuffers" version="2.4.1.555" targetFramework="net46" />
-  <package id="Hyperion" version="0.9.2" targetFramework="net46" />
+  <package id="Hyperion" version="0.9.8" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Threading" version="15.4.4" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Validation" version="15.3.15" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
   <package id="Reactive.Streams" version="1.0.2" targetFramework="net46" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net46" />
-  <package id="System.ValueTuple" version="4.3.0" targetFramework="net46" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net46" />
 </packages>

--- a/CurryOn.Akka.Persistence.Indexed/Actors.fs
+++ b/CurryOn.Akka.Persistence.Indexed/Actors.fs
@@ -140,7 +140,7 @@ type EventsbyPersistenceIdPublisher (liveQuery, persistenceId, fromSequence, toS
             match message with
             | :? ReplayedMessage as replayed ->
                 let sequence = replayed.Persistent.SequenceNr
-                buffer.Buffer(new EventEnvelope(sequence, persistenceId, sequence, replayed.Persistent.Payload))
+                buffer.Buffer(new EventEnvelope(Offset.Sequence(sequence), persistenceId, sequence, replayed.Persistent.Payload))
                 currentSequence := sequence + 1L
                 buffer.Deliver(publisher.TotalDemand) |> handled
             | :? RecoverySuccess as success ->
@@ -224,7 +224,7 @@ type EventsByTagPublisher (liveQuery, tag, fromOffset, maxBufferSize: int64, plu
             | :? ReplayEvents as event ->
                 match event with
                 | ReplayedTaggedMessage (eventOffset,eventTag,persistent) ->
-                    buffer.Buffer(new EventEnvelope(eventOffset, persistent.PersistenceId, persistent.SequenceNr, persistent.Payload))
+                    buffer.Buffer(new EventEnvelope(Offset.Sequence(eventOffset), persistent.PersistenceId, persistent.SequenceNr, persistent.Payload))
                     currentOffset := eventOffset
                     buffer.Deliver(publisher.TotalDemand) |> handled
             | :? RecoverySuccess as success ->

--- a/CurryOn.Akka.Persistence.Indexed/CurryOn.Akka.Persistence.Indexed.fsproj
+++ b/CurryOn.Akka.Persistence.Indexed/CurryOn.Akka.Persistence.Indexed.fsproj
@@ -60,22 +60,22 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Akka">
-      <HintPath>..\packages\Akka.1.3.4\lib\net45\Akka.dll</HintPath>
+      <HintPath>..\packages\Akka.1.3.8\lib\net45\Akka.dll</HintPath>
     </Reference>
     <Reference Include="Akka.FSharp">
-      <HintPath>..\packages\Akka.FSharp.1.2.3\lib\net45\Akka.FSharp.dll</HintPath>
+      <HintPath>..\packages\Akka.FSharp.1.3.8\lib\net45\Akka.FSharp.dll</HintPath>
     </Reference>
     <Reference Include="Akka.Persistence">
-      <HintPath>..\packages\Akka.Persistence.1.2.3.43-beta\lib\net45\Akka.Persistence.dll</HintPath>
+      <HintPath>..\packages\Akka.Persistence.1.3.8\lib\net45\Akka.Persistence.dll</HintPath>
     </Reference>
     <Reference Include="Akka.Persistence.Query">
-      <HintPath>..\packages\Akka.Persistence.Query.1.2.3.43-beta\lib\net45\Akka.Persistence.Query.dll</HintPath>
+      <HintPath>..\packages\Akka.Persistence.Query.1.3.8\lib\net45\Akka.Persistence.Query.dll</HintPath>
     </Reference>
     <Reference Include="Akka.Streams">
-      <HintPath>..\packages\Akka.Streams.1.2.3\lib\net45\Akka.Streams.dll</HintPath>
+      <HintPath>..\packages\Akka.Streams.1.3.8\lib\net45\Akka.Streams.dll</HintPath>
     </Reference>
     <Reference Include="FSharp.Core">
-      <HintPath>..\packages\FSharp.Core.4.1.17\lib\net45\FSharp.Core.dll</HintPath>
+      <HintPath>..\packages\FSharp.Core.4.2.3\lib\net45\FSharp.Core.dll</HintPath>
     </Reference>
     <Reference Include="FSharp.PowerPack">
       <HintPath>..\packages\FSPowerPack.Core.Community.3.0.0.0\Lib\Net40\FSharp.PowerPack.dll</HintPath>
@@ -83,11 +83,14 @@
     <Reference Include="FSharp.PowerPack.Linq">
       <HintPath>..\packages\FSPowerPack.Linq.Community.3.0.0.0\Lib\Net40\FSharp.PowerPack.Linq.dll</HintPath>
     </Reference>
+    <Reference Include="FSharp.Quotations.Evaluator">
+      <HintPath>..\packages\FSharp.Quotations.Evaluator.1.1.2\lib\net45\FSharp.Quotations.Evaluator.dll</HintPath>
+    </Reference>
     <Reference Include="FsPickler">
-      <HintPath>..\packages\FsPickler.3.2.0\lib\net45\FsPickler.dll</HintPath>
+      <HintPath>..\packages\FsPickler.5.2\lib\net45\FsPickler.dll</HintPath>
     </Reference>
     <Reference Include="FsPickler.Json">
-      <HintPath>..\packages\FsPickler.Json.3.2.0\lib\net45\FsPickler.Json.dll</HintPath>
+      <HintPath>..\packages\FsPickler.Json.5.0\lib\net45\FsPickler.Json.dll</HintPath>
     </Reference>
     <Reference Include="Google.Protobuf">
       <HintPath>..\packages\Google.Protobuf.3.3.0\lib\net45\Google.Protobuf.dll</HintPath>
@@ -114,7 +117,8 @@
     <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ValueTuple">
-      <HintPath>..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/CurryOn.Akka.Persistence.Indexed/QueryJournal.fs
+++ b/CurryOn.Akka.Persistence.Indexed/QueryJournal.fs
@@ -31,6 +31,11 @@ type IndexedQueryReadJournalBase (system: ExtendedActorSystem, config: Config, i
               .MapMaterializedValue(fun _ -> NotUsed.Instance)
               .Named("AllPesistenceIds") |> unbox<Source<string,NotUsed>>
 
+    member __.PersistenceIds () =
+        Source.ActorPublisher<string>(PersistenceIdsPublisher.Props(true, identifier))
+              .MapMaterializedValue(fun _ -> NotUsed.Instance)
+              .Named("AllPesistenceIds") |> unbox<Source<string,NotUsed>>
+
     member __.EventsByPersistenceId (persistenceId, fromSequence, toSequence) =
         Source.ActorPublisher<EventEnvelope>(EventsbyPersistenceIdPublisher.Props(true, persistenceId, fromSequence, toSequence, maxBufferSize, identifier))
               .MapMaterializedValue(fun _ -> NotUsed.Instance)
@@ -42,9 +47,9 @@ type IndexedQueryReadJournalBase (system: ExtendedActorSystem, config: Config, i
               .Named("EventsByTag") |> unbox<Source<EventEnvelope,NotUsed>>
 
     interface IReadJournal
-    interface IAllPersistenceIdsQuery with
-        member journal.AllPersistenceIds () = 
-            journal.AllPersistenceIds()           
+    interface IPersistenceIdsQuery with
+        member journal.PersistenceIds () = 
+            journal.PersistenceIds()           
     interface ICurrentEventsByPersistenceIdQuery with
         member journal.CurrentEventsByPersistenceId (persistenceId, fromSequence, toSequence) =
             journal.CurrentEventsByPersistenceId(persistenceId, fromSequence, toSequence)

--- a/CurryOn.Akka.Persistence.Indexed/packages.config
+++ b/CurryOn.Akka.Persistence.Indexed/packages.config
@@ -1,13 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Akka" version="1.3.4" targetFramework="net46" />
-  <package id="Akka.FSharp" version="1.2.3" targetFramework="net46" />
-  <package id="Akka.Persistence" version="1.2.3.43-beta" targetFramework="net46" />
-  <package id="Akka.Persistence.Query" version="1.2.3.43-beta" targetFramework="net46" />
-  <package id="Akka.Streams" version="1.2.3" targetFramework="net46" />
-  <package id="FSharp.Core" version="4.1.17" targetFramework="net46" />
-  <package id="FsPickler" version="3.2.0" targetFramework="net46" />
-  <package id="FsPickler.Json" version="3.2.0" targetFramework="net46" />
+  <package id="Akka" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.FSharp" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.Persistence" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.Persistence.Query" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.Streams" version="1.3.8" targetFramework="net46" />
+  <package id="FSharp.Core" version="4.2.3" targetFramework="net46" />
+  <package id="FSharp.Quotations.Evaluator" version="1.1.2" targetFramework="net46" />
+  <package id="FsPickler" version="5.2" targetFramework="net46" />
+  <package id="FsPickler.Json" version="5.0" targetFramework="net46" />
   <package id="FSPowerPack.Core.Community" version="3.0.0.0" targetFramework="net46" />
   <package id="FSPowerPack.Linq.Community" version="3.0.0.0" targetFramework="net46" />
   <package id="Google.Protobuf" version="3.3.0" targetFramework="net46" />
@@ -15,5 +16,5 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
   <package id="Reactive.Streams" version="1.0.2" targetFramework="net46" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net46" />
-  <package id="System.ValueTuple" version="4.3.0" targetFramework="net46" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net46" />
 </packages>

--- a/CurryOn.Akka.Persistence.Kafka/CurryOn.Akka.Persistence.Kafka.fsproj
+++ b/CurryOn.Akka.Persistence.Kafka/CurryOn.Akka.Persistence.Kafka.fsproj
@@ -60,19 +60,19 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Akka">
-      <HintPath>..\packages\Akka.1.2.3\lib\net45\Akka.dll</HintPath>
+      <HintPath>..\packages\Akka.1.3.8\lib\net45\Akka.dll</HintPath>
     </Reference>
     <Reference Include="Akka.FSharp">
-      <HintPath>..\packages\Akka.FSharp.1.2.3\lib\net45\Akka.FSharp.dll</HintPath>
+      <HintPath>..\packages\Akka.FSharp.1.3.8\lib\net45\Akka.FSharp.dll</HintPath>
     </Reference>
     <Reference Include="Akka.Persistence">
-      <HintPath>..\packages\Akka.Persistence.1.2.3.43-beta\lib\net45\Akka.Persistence.dll</HintPath>
+      <HintPath>..\packages\Akka.Persistence.1.3.8\lib\net45\Akka.Persistence.dll</HintPath>
     </Reference>
     <Reference Include="Akka.Persistence.Query">
-      <HintPath>..\packages\Akka.Persistence.Query.1.2.3.43-beta\lib\net45\Akka.Persistence.Query.dll</HintPath>
+      <HintPath>..\packages\Akka.Persistence.Query.1.3.8\lib\net45\Akka.Persistence.Query.dll</HintPath>
     </Reference>
     <Reference Include="Akka.Streams">
-      <HintPath>..\packages\Akka.Streams.1.2.3\lib\net45\Akka.Streams.dll</HintPath>
+      <HintPath>..\packages\Akka.Streams.1.3.8\lib\net45\Akka.Streams.dll</HintPath>
     </Reference>
     <Reference Include="Crc32C.NET">
       <HintPath>..\packages\Crc32C.NET.1.0.2.2\lib\net20\Crc32C.NET.dll</HintPath>
@@ -81,7 +81,7 @@
       <HintPath>..\packages\FSharp.Control.AsyncSeq.2.0.18\lib\net45\FSharp.Control.AsyncSeq.dll</HintPath>
     </Reference>
     <Reference Include="FSharp.Core">
-      <HintPath>..\packages\FSharp.Core.4.1.17\lib\net45\FSharp.Core.dll</HintPath>
+      <HintPath>..\packages\FSharp.Core.4.2.3\lib\net45\FSharp.Core.dll</HintPath>
     </Reference>
     <Reference Include="FSharp.PowerPack">
       <HintPath>..\packages\FSPowerPack.Core.Community.3.0.0.0\Lib\Net40\FSharp.PowerPack.dll</HintPath>
@@ -89,8 +89,14 @@
     <Reference Include="FSharp.PowerPack.Linq">
       <HintPath>..\packages\FSPowerPack.Linq.Community.3.0.0.0\Lib\Net40\FSharp.PowerPack.Linq.dll</HintPath>
     </Reference>
+    <Reference Include="FSharp.Quotations.Evaluator">
+      <HintPath>..\packages\FSharp.Quotations.Evaluator.1.1.2\lib\net45\FSharp.Quotations.Evaluator.dll</HintPath>
+    </Reference>
     <Reference Include="FsPickler">
-      <HintPath>..\packages\FsPickler.3.2.0\lib\net45\FsPickler.dll</HintPath>
+      <HintPath>..\packages\FsPickler.5.2\lib\net45\FsPickler.dll</HintPath>
+    </Reference>
+    <Reference Include="Google.Protobuf">
+      <HintPath>..\packages\Google.Protobuf.3.3.0\lib\net45\Google.Protobuf.dll</HintPath>
     </Reference>
     <Reference Include="Google.ProtocolBuffers">
       <HintPath>..\packages\Google.ProtocolBuffers.2.4.1.555\lib\net40\Google.ProtocolBuffers.dll</HintPath>
@@ -115,11 +121,13 @@
     <Reference Include="System.Collections.Immutable">
       <HintPath>..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ValueTuple">
-      <HintPath>..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/CurryOn.Akka.Persistence.Kafka/packages.config
+++ b/CurryOn.Akka.Persistence.Kafka/packages.config
@@ -1,21 +1,23 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Akka" version="1.2.3" targetFramework="net46" />
-  <package id="Akka.FSharp" version="1.2.3" targetFramework="net46" />
-  <package id="Akka.Persistence" version="1.2.3.43-beta" targetFramework="net46" />
-  <package id="Akka.Persistence.Query" version="1.2.3.43-beta" targetFramework="net46" />
-  <package id="Akka.Streams" version="1.2.3" targetFramework="net46" />
+  <package id="Akka" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.FSharp" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.Persistence" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.Persistence.Query" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.Streams" version="1.3.8" targetFramework="net46" />
   <package id="Crc32C.NET" version="1.0.2.2" targetFramework="net46" />
   <package id="FSharp.Control.AsyncSeq" version="2.0.18" targetFramework="net46" />
-  <package id="FSharp.Core" version="4.1.17" targetFramework="net46" />
-  <package id="FsPickler" version="3.2.0" targetFramework="net46" />
+  <package id="FSharp.Core" version="4.2.3" targetFramework="net46" />
+  <package id="FSharp.Quotations.Evaluator" version="1.1.2" targetFramework="net46" />
+  <package id="FsPickler" version="5.2" targetFramework="net46" />
   <package id="FSPowerPack.Core.Community" version="3.0.0.0" targetFramework="net46" />
   <package id="FSPowerPack.Linq.Community" version="3.0.0.0" targetFramework="net46" />
+  <package id="Google.Protobuf" version="3.3.0" targetFramework="net46" />
   <package id="Google.ProtocolBuffers" version="2.4.1.555" targetFramework="net46" />
   <package id="Kafunk" version="0.1.13" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
   <package id="Reactive.Streams" version="1.0.2" targetFramework="net46" />
   <package id="Snappy.NET" version="1.1.1.4" targetFramework="net46" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net46" />
-  <package id="System.ValueTuple" version="4.3.0" targetFramework="net46" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net46" />
 </packages>

--- a/CurryOn.Akka.Persistence.Streaming/CurryOn.Akka.Persistence.Streaming.fsproj
+++ b/CurryOn.Akka.Persistence.Streaming/CurryOn.Akka.Persistence.Streaming.fsproj
@@ -59,25 +59,25 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Akka">
-      <HintPath>..\packages\Akka.1.2.3\lib\net45\Akka.dll</HintPath>
+      <HintPath>..\packages\Akka.1.3.8\lib\net45\Akka.dll</HintPath>
     </Reference>
     <Reference Include="Akka.FSharp">
-      <HintPath>..\packages\Akka.FSharp.1.2.3\lib\net45\Akka.FSharp.dll</HintPath>
+      <HintPath>..\packages\Akka.FSharp.1.3.8\lib\net45\Akka.FSharp.dll</HintPath>
     </Reference>
     <Reference Include="Akka.Persistence">
-      <HintPath>..\packages\Akka.Persistence.1.2.3.43-beta\lib\net45\Akka.Persistence.dll</HintPath>
+      <HintPath>..\packages\Akka.Persistence.1.3.8\lib\net45\Akka.Persistence.dll</HintPath>
     </Reference>
     <Reference Include="Akka.Persistence.FSharp">
-      <HintPath>..\packages\Akka.Persistence.FSharp.1.2.3.43-beta\lib\net45\Akka.Persistence.FSharp.dll</HintPath>
+      <HintPath>..\packages\Akka.Persistence.FSharp.1.3.8\lib\net45\Akka.Persistence.FSharp.dll</HintPath>
     </Reference>
     <Reference Include="Akka.Persistence.Query">
-      <HintPath>..\packages\Akka.Persistence.Query.1.2.3.43-beta\lib\net45\Akka.Persistence.Query.dll</HintPath>
+      <HintPath>..\packages\Akka.Persistence.Query.1.3.8\lib\net45\Akka.Persistence.Query.dll</HintPath>
     </Reference>
     <Reference Include="Akka.Streams">
-      <HintPath>..\packages\Akka.Streams.1.2.3\lib\net45\Akka.Streams.dll</HintPath>
+      <HintPath>..\packages\Akka.Streams.1.3.8\lib\net45\Akka.Streams.dll</HintPath>
     </Reference>
     <Reference Include="FSharp.Core">
-      <HintPath>..\packages\FSharp.Core.4.1.17\lib\net45\FSharp.Core.dll</HintPath>
+      <HintPath>..\packages\FSharp.Core.4.2.3\lib\net45\FSharp.Core.dll</HintPath>
     </Reference>
     <Reference Include="FSharp.PowerPack">
       <HintPath>..\packages\FSPowerPack.Core.Community.3.0.0.0\Lib\Net40\FSharp.PowerPack.dll</HintPath>
@@ -85,11 +85,17 @@
     <Reference Include="FSharp.PowerPack.Linq">
       <HintPath>..\packages\FSPowerPack.Linq.Community.3.0.0.0\Lib\Net40\FSharp.PowerPack.Linq.dll</HintPath>
     </Reference>
+    <Reference Include="FSharp.Quotations.Evaluator">
+      <HintPath>..\packages\FSharp.Quotations.Evaluator.1.1.2\lib\net45\FSharp.Quotations.Evaluator.dll</HintPath>
+    </Reference>
     <Reference Include="FsPickler">
-      <HintPath>..\packages\FsPickler.3.2.0\lib\net45\FsPickler.dll</HintPath>
+      <HintPath>..\packages\FsPickler.5.2\lib\net45\FsPickler.dll</HintPath>
     </Reference>
     <Reference Include="FsPickler.Json">
-      <HintPath>..\packages\FsPickler.Json.3.2.0\lib\net45\FsPickler.Json.dll</HintPath>
+      <HintPath>..\packages\FsPickler.Json.5.0\lib\net45\FsPickler.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Google.Protobuf">
+      <HintPath>..\packages\Google.Protobuf.3.3.0\lib\net45\Google.Protobuf.dll</HintPath>
     </Reference>
     <Reference Include="Google.ProtocolBuffers">
       <HintPath>..\packages\Google.ProtocolBuffers.2.4.1.555\lib\net40\Google.ProtocolBuffers.dll</HintPath>
@@ -108,11 +114,13 @@
     <Reference Include="System.Collections.Immutable">
       <HintPath>..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ValueTuple">
-      <HintPath>..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/CurryOn.Akka.Persistence.Streaming/packages.config
+++ b/CurryOn.Akka.Persistence.Streaming/packages.config
@@ -1,19 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Akka" version="1.2.3" targetFramework="net46" />
-  <package id="Akka.FSharp" version="1.2.3" targetFramework="net46" />
-  <package id="Akka.Persistence" version="1.2.3.43-beta" targetFramework="net46" />
-  <package id="Akka.Persistence.FSharp" version="1.2.3.43-beta" targetFramework="net46" />
-  <package id="Akka.Persistence.Query" version="1.2.3.43-beta" targetFramework="net46" />
-  <package id="Akka.Streams" version="1.2.3" targetFramework="net46" />
-  <package id="FSharp.Core" version="4.1.17" targetFramework="net46" />
-  <package id="FsPickler" version="3.2.0" targetFramework="net46" />
-  <package id="FsPickler.Json" version="3.2.0" targetFramework="net46" />
+  <package id="Akka" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.FSharp" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.Persistence" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.Persistence.FSharp" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.Persistence.Query" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.Streams" version="1.3.8" targetFramework="net46" />
+  <package id="FSharp.Core" version="4.2.3" targetFramework="net46" />
+  <package id="FSharp.Quotations.Evaluator" version="1.1.2" targetFramework="net46" />
+  <package id="FsPickler" version="5.2" targetFramework="net46" />
+  <package id="FsPickler.Json" version="5.0" targetFramework="net46" />
   <package id="FSPowerPack.Core.Community" version="3.0.0.0" targetFramework="net46" />
   <package id="FSPowerPack.Linq.Community" version="3.0.0.0" targetFramework="net46" />
+  <package id="Google.Protobuf" version="3.3.0" targetFramework="net46" />
   <package id="Google.ProtocolBuffers" version="2.4.1.555" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
   <package id="Reactive.Streams" version="1.0.2" targetFramework="net46" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net46" />
-  <package id="System.ValueTuple" version="4.3.0" targetFramework="net46" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net46" />
 </packages>

--- a/CurryOn.Core/CurryOn.Core.fsproj
+++ b/CurryOn.Core/CurryOn.Core.fsproj
@@ -64,19 +64,19 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Akka">
-      <HintPath>..\packages\Akka.1.2.3\lib\net45\Akka.dll</HintPath>
+      <HintPath>..\packages\Akka.1.3.8\lib\net45\Akka.dll</HintPath>
     </Reference>
     <Reference Include="Akka.FSharp">
-      <HintPath>..\packages\Akka.FSharp.1.2.3\lib\net45\Akka.FSharp.dll</HintPath>
+      <HintPath>..\packages\Akka.FSharp.1.3.8\lib\net45\Akka.FSharp.dll</HintPath>
     </Reference>
     <Reference Include="Akka.Persistence">
-      <HintPath>..\packages\Akka.Persistence.1.2.3.43-beta\lib\net45\Akka.Persistence.dll</HintPath>
+      <HintPath>..\packages\Akka.Persistence.1.3.8\lib\net45\Akka.Persistence.dll</HintPath>
     </Reference>
     <Reference Include="Akka.Persistence.FSharp">
-      <HintPath>..\packages\Akka.Persistence.FSharp.1.2.3.43-beta\lib\net45\Akka.Persistence.FSharp.dll</HintPath>
+      <HintPath>..\packages\Akka.Persistence.FSharp.1.3.8\lib\net45\Akka.Persistence.FSharp.dll</HintPath>
     </Reference>
     <Reference Include="FSharp.Core">
-      <HintPath>..\Samples\CurryOn.Blog\packages\FSharp.Core.4.1.17\lib\net45\FSharp.Core.dll</HintPath>
+      <HintPath>..\packages\FSharp.Core.4.2.3\lib\net45\FSharp.Core.dll</HintPath>
     </Reference>
     <Reference Include="FSharp.PowerPack">
       <HintPath>..\packages\FSPowerPack.Core.Community.3.0.0.0\lib\Net40\FSharp.PowerPack.dll</HintPath>
@@ -84,11 +84,17 @@
     <Reference Include="FSharp.PowerPack.Linq">
       <HintPath>..\packages\FSPowerPack.Linq.Community.3.0.0.0\lib\Net40\FSharp.PowerPack.Linq.dll</HintPath>
     </Reference>
+    <Reference Include="FSharp.Quotations.Evaluator">
+      <HintPath>..\packages\FSharp.Quotations.Evaluator.1.1.2\lib\net45\FSharp.Quotations.Evaluator.dll</HintPath>
+    </Reference>
     <Reference Include="FsPickler">
-      <HintPath>..\packages\FsPickler.3.2.0\lib\net45\FsPickler.dll</HintPath>
+      <HintPath>..\packages\FsPickler.5.2\lib\net45\FsPickler.dll</HintPath>
     </Reference>
     <Reference Include="FsPickler.Json">
-      <HintPath>..\packages\FsPickler.Json.3.2.0\lib\net45\FsPickler.Json.dll</HintPath>
+      <HintPath>..\packages\FsPickler.Json.5.0\lib\net45\FsPickler.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Google.Protobuf">
+      <HintPath>..\packages\Google.Protobuf.3.3.0\lib\net45\Google.Protobuf.dll</HintPath>
     </Reference>
     <Reference Include="Google.ProtocolBuffers">
       <HintPath>..\packages\Google.ProtocolBuffers.2.4.1.555\lib\net40\Google.ProtocolBuffers.dll</HintPath>
@@ -110,7 +116,8 @@
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.ValueTuple">
-      <HintPath>..\Samples\CurryOn.Blog\packages\System.ValueTuple.4.4.0-preview2-25405-01\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/CurryOn.Core/Script.fsx
+++ b/CurryOn.Core/Script.fsx
@@ -1,8 +1,8 @@
 ﻿#r "System.Configuration"
 #r "System.Runtime.Serialization"
 #r "System.Xml"
-#r @"..\packages\Akka.1.1.3\lib\net45\Akka.dll"
-#r @"..\packages\Akka.FSharp.1.1.3\lib\net45\Akka.FSharp.dll"
+#r @"..\packages\Akka.1.3.8\lib\net45\Akka.dll"
+#r @"..\packages\Akka.FSharp.1.3.8\lib\net45\Akka.FSharp.dll"
 #r @"..\packages\FSPowerPack.Core.Community.3.0.0.0\lib\Net40\FSharp.PowerPack.dll"
 #r @"..\packages\FSPowerPack.Linq.Community.3.0.0.0\lib\Net40\FSharp.PowerPack.Linq.dll"
 #r @"..\packages\FsPickler.3.2.0\lib\net45\FsPickler.dll"
@@ -12,6 +12,8 @@
 #r @"..\packages\FSharp.Quotations.Evaluator.1.0.7\lib\net40\FSharp.Quotations.Evaluator.dll"
 #r @"..\CurryOn.Common\bin\debug\CurryOn.Common.dll"
 #r @"..\CurryOn.DependencyInjection\bin\debug\CurryOn.DependencyInjection.dll"
+#r @"F:\source\CurryOn\CurryOn.FSharp.Control\bin\Debug\CurryOn.FSharp.Control.dll"
+
 #load "Messaging.fs"
 #load "Serialization.fs"
 
@@ -33,42 +35,41 @@ type DomainClassification =
 type DomainEntity =
     {
         Id: Guid;
-        Name: string<AggregateName>;
+        Name: string;
         Classification: DomainClassification;
     }
-    interface IEntity with
-        member this.Id = this.Id.ToString() |> EntityId.New
+    
 
-type DomainEvent =
-    {
-        Id: Guid;
-        Name: string<AggregateName>
-        Version: int<version>
-    }
-    member this.AggregateKey = this.Id.ToString() |> AggregateKey.New
-    interface IEvent with
-        member this.MessageId = Guid.NewGuid()
-        member this.CorrelationId = Guid.NewGuid()
-        member this.MessageDate = DateTime.UtcNow
-        member this.Key = this.AggregateKey
-        member this.Name = "DomainAggregate" |> AggregateName.New
-        member this.Tenant = None
-        member this.DatePublished = None
-        member this.ConsistentHashKey = this.AggregateKey |> box
+//type DomainEvent =
+//    {
+//        Id: Guid;
+//        Name: string
+//        Version: int
+//    }
+//    member this.AggregateKey = (sprintf "%A-%A" ("Test", this.Id.ToString()))
+//    interface IEvent with
+//        member this.MessageId = Guid.NewGuid()
+//        member this.CorrelationId = Guid.NewGuid()
+//        member this.MessageDate = DateTime.UtcNow
+//        member this.Key = this.AggregateKey
+//        member this.Name = "DomainAggregate" |> AggregateName.New
+//        member this.Tenant = None
+//        member this.DatePublished = None
+//        member this.ConsistentHashKey = this.AggregateKey |> box
 
 [<CLIMutable>] 
 type DomainAggregate =
     {
         Root: DomainEntity;
-        LastEvent: int<version>;
+        LastEvent: int64;
     }
-    member this.AggregateKey = this.Root.Id.ToString() |> AggregateKey.New
+    member this.AggregateKey = (sprintf "%A-%A" ("Test", this.Root.Id.ToString())) 
     interface IAggregate with
-        member this.Root= this.Root :> IEntity
-        member this.Key = this.AggregateKey
-        member this.Name = typeof<DomainAggregate>.AggregateName
+        //member this.Root= this.Root :> IEntity
+        //member this.Key = this.AggregateKey
+        //member this.Name = typeof<DomainAggregate>.AggregateName
         member this.Tenant = None
-        member this.LastEvent = this.LastEvent
+        //member this.LastEvent = this.LastEvent
         member this.Apply event version =
             match event with
             | :? DomainEvent as domainEvent -> {this with Root = {this.Root with Name = domainEvent.Name}; LastEvent = version}

--- a/CurryOn.Core/Serialization.fs
+++ b/CurryOn.Core/Serialization.fs
@@ -13,7 +13,7 @@ module Serialization =
     let Utf8 = UTF8Encoding(false)
 
     // FsPickler Serializers
-    let private JsonSerializer = JsonSerializer(indent = true)
+    let private JsonSerializer = JsonSerializer(indent = true, omitHeader = true)
     let private BinarySerializer = BinarySerializer(forceLittleEndian = true)
     let private BsonSerializer = BsonSerializer()
     let private XmlSerializer = XmlSerializer(indent = true)    

--- a/CurryOn.Core/packages.config
+++ b/CurryOn.Core/packages.config
@@ -1,16 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Akka" version="1.2.3" targetFramework="net46" />
-  <package id="Akka.FSharp" version="1.2.3" targetFramework="net46" />
-  <package id="Akka.Persistence" version="1.2.3.43-beta" targetFramework="net46" />
-  <package id="Akka.Persistence.FSharp" version="1.2.3.43-beta" targetFramework="net46" />
-  <package id="FSharp.Core" version="4.1.17" targetFramework="net46" />
-  <package id="FsPickler" version="3.2.0" targetFramework="net46" />
-  <package id="FsPickler.Json" version="3.2.0" targetFramework="net46" />
+  <package id="Akka" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.FSharp" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.Persistence" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.Persistence.FSharp" version="1.3.8" targetFramework="net46" />
+  <package id="FSharp.Core" version="4.2.3" targetFramework="net46" />
+  <package id="FSharp.Quotations.Evaluator" version="1.1.2" targetFramework="net46" />
+  <package id="FsPickler" version="5.2" targetFramework="net46" />
+  <package id="FsPickler.Json" version="5.0" targetFramework="net46" />
   <package id="FSPowerPack.Core.Community" version="3.0.0.0" targetFramework="net46" />
   <package id="FSPowerPack.Linq.Community" version="3.0.0.0" targetFramework="net46" />
+  <package id="Google.Protobuf" version="3.3.0" targetFramework="net46" />
   <package id="Google.ProtocolBuffers" version="2.4.1.555" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net46" />
   <package id="System.Collections.Immutable" version="1.4.0-preview2-25405-01" targetFramework="net46" />
-  <package id="System.ValueTuple" version="4.4.0-preview2-25405-01" targetFramework="net46" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net46" />
 </packages>

--- a/CurryOn.DependencyInjection/packages.config
+++ b/CurryOn.DependencyInjection/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="FSharp.Core" version="4.1.17" targetFramework="net46" />
+  <package id="System.ValueTuple" version="4.3.0" targetFramework="net46" />
+</packages>

--- a/CurryOn.Tests/CurryOn.Tests.fsproj
+++ b/CurryOn.Tests/CurryOn.Tests.fsproj
@@ -63,40 +63,37 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Akka">
-      <HintPath>..\packages\Akka.1.2.3\lib\net45\Akka.dll</HintPath>
+      <HintPath>..\packages\Akka.1.3.8\lib\net45\Akka.dll</HintPath>
     </Reference>
     <Reference Include="Akka.FSharp">
-      <HintPath>..\packages\Akka.FSharp.1.2.3\lib\net45\Akka.FSharp.dll</HintPath>
+      <HintPath>..\packages\Akka.FSharp.1.3.8\lib\net45\Akka.FSharp.dll</HintPath>
     </Reference>
     <Reference Include="Akka.Persistence">
-      <HintPath>..\packages\Akka.Persistence.1.2.3.43-beta\lib\net45\Akka.Persistence.dll</HintPath>
+      <HintPath>..\packages\Akka.Persistence.1.3.8\lib\net45\Akka.Persistence.dll</HintPath>
     </Reference>
     <Reference Include="Akka.Persistence.FSharp">
-      <HintPath>..\packages\Akka.Persistence.FSharp.1.2.3.43-beta\lib\net45\Akka.Persistence.FSharp.dll</HintPath>
+      <HintPath>..\packages\Akka.Persistence.FSharp.1.3.8\lib\net45\Akka.Persistence.FSharp.dll</HintPath>
     </Reference>
     <Reference Include="Akka.Persistence.Query">
-      <HintPath>..\packages\Akka.Persistence.Query.1.2.3.43-beta\lib\net45\Akka.Persistence.Query.dll</HintPath>
+      <HintPath>..\packages\Akka.Persistence.Query.1.3.8\lib\net45\Akka.Persistence.Query.dll</HintPath>
     </Reference>
     <Reference Include="Akka.Persistence.Query.Sql">
-      <HintPath>..\packages\Akka.Persistence.Query.Sql.1.2.3.43-beta\lib\net45\Akka.Persistence.Query.Sql.dll</HintPath>
+      <HintPath>..\packages\Akka.Persistence.Query.Sql.1.3.8\lib\net45\Akka.Persistence.Query.Sql.dll</HintPath>
     </Reference>
     <Reference Include="Akka.Persistence.Sql.Common">
-      <HintPath>..\packages\Akka.Persistence.Sql.Common.1.2.3.43-beta\lib\net45\Akka.Persistence.Sql.Common.dll</HintPath>
+      <HintPath>..\packages\Akka.Persistence.Sql.Common.1.3.8\lib\net45\Akka.Persistence.Sql.Common.dll</HintPath>
     </Reference>
     <Reference Include="Akka.Persistence.SqlServer">
-      <HintPath>..\packages\Akka.Persistence.SqlServer.1.1.1.7-beta\lib\net45\Akka.Persistence.SqlServer.dll</HintPath>
+      <HintPath>..\packages\Akka.Persistence.SqlServer.1.3.7\lib\net45\Akka.Persistence.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="Akka.Serialization.Hyperion">
-      <HintPath>..\packages\Akka.Serialization.Hyperion.1.2.3.43-beta\lib\net45\Akka.Serialization.Hyperion.dll</HintPath>
+      <HintPath>..\packages\Akka.Serialization.Hyperion.1.3.8-beta66\lib\net45\Akka.Serialization.Hyperion.dll</HintPath>
     </Reference>
     <Reference Include="Akka.Streams">
-      <HintPath>..\packages\Akka.Streams.1.2.3\lib\net45\Akka.Streams.dll</HintPath>
+      <HintPath>..\packages\Akka.Streams.1.3.8\lib\net45\Akka.Streams.dll</HintPath>
     </Reference>
     <Reference Include="Akka.TestKit">
-      <HintPath>..\packages\Akka.TestKit.1.2.3\lib\net45\Akka.TestKit.dll</HintPath>
-    </Reference>
-    <Reference Include="Dandh.Monitoring.Domain">
-      <HintPath>..\..\..\Domain\Monitoring\Dandh.Monitoring\Dandh.Monitoring.Domain\bin\Debug\Dandh.Monitoring.Domain.dll</HintPath>
+      <HintPath>..\packages\Akka.TestKit.1.3.8\lib\net45\Akka.TestKit.dll</HintPath>
     </Reference>
     <Reference Include="Elasticsearch.Net">
       <HintPath>..\packages\Elasticsearch.Net.5.6.0\lib\net46\Elasticsearch.Net.dll</HintPath>
@@ -105,7 +102,7 @@
       <HintPath>..\packages\EventStore.Client.4.0.3\lib\net40\EventStore.ClientAPI.dll</HintPath>
     </Reference>
     <Reference Include="FSharp.Core">
-      <HintPath>..\packages\FSharp.Core.4.1.17\lib\net45\FSharp.Core.dll</HintPath>
+      <HintPath>..\packages\FSharp.Core.4.2.3\lib\net45\FSharp.Core.dll</HintPath>
     </Reference>
     <Reference Include="FSharp.PowerPack">
       <HintPath>..\packages\FSPowerPack.Core.Community.3.0.0.0\Lib\Net40\FSharp.PowerPack.dll</HintPath>
@@ -113,8 +110,11 @@
     <Reference Include="FSharp.PowerPack.Linq">
       <HintPath>..\packages\FSPowerPack.Linq.Community.3.0.0.0\Lib\Net40\FSharp.PowerPack.Linq.dll</HintPath>
     </Reference>
+    <Reference Include="FSharp.Quotations.Evaluator">
+      <HintPath>..\packages\FSharp.Quotations.Evaluator.1.1.2\lib\net45\FSharp.Quotations.Evaluator.dll</HintPath>
+    </Reference>
     <Reference Include="FsPickler">
-      <HintPath>..\packages\FsPickler.3.2.0\lib\net45\FsPickler.dll</HintPath>
+      <HintPath>..\packages\FsPickler.5.2\lib\net45\FsPickler.dll</HintPath>
     </Reference>
     <Reference Include="Google.Protobuf">
       <HintPath>..\packages\Google.Protobuf.3.3.0\lib\net45\Google.Protobuf.dll</HintPath>
@@ -126,7 +126,7 @@
       <HintPath>..\packages\Google.ProtocolBuffers.2.4.1.555\lib\net40\Google.ProtocolBuffers.Serialization.dll</HintPath>
     </Reference>
     <Reference Include="Hyperion">
-      <HintPath>..\packages\Hyperion.0.9.2\lib\net45\Hyperion.dll</HintPath>
+      <HintPath>..\packages\Hyperion.0.9.8\lib\net45\Hyperion.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework">
@@ -152,9 +152,11 @@
     <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ValueTuple">
-      <HintPath>..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CurryOn.Akka.Persistence.Common\CurryOn.Akka.Persistence.Common.fsproj">

--- a/CurryOn.Tests/ElasticsearchTests.fs
+++ b/CurryOn.Tests/ElasticsearchTests.fs
@@ -27,7 +27,7 @@ type SalesOrder =
 type ElasticDslTests() =
     [<TestMethod>]
     member __.``Test Dsl.first`` () =
-        let settings = {Node = Uri "http://corpweiapd001:9200"; DisableDirectStreaming = true; RequestTimeout = TimeSpan.FromMinutes 1.0; DefaultIndex = Some "sales_orders"; IndexMappings = [{IndexName = "sales_orders"; TypeName = "sales_order"; Type = typeof<SalesOrder>}]}
+        let settings = {Node = Uri "http://localhost:9200"; DisableDirectStreaming = true; RequestTimeout = TimeSpan.FromMinutes 1.0; DefaultIndex = Some "sales_orders"; IndexMappings = [{IndexName = "sales_orders"; TypeName = "sales_order"; Type = typeof<SalesOrder>}]}
         let client = Elasticsearch.connect settings 
         let result = (MatchAll None) |> Dsl.first<SalesOrder> client None (FieldDirection ("id",Descending)) |> Operation.returnOrFail
         match result with

--- a/CurryOn.Tests/EventStorePersistenceTests.fs
+++ b/CurryOn.Tests/EventStorePersistenceTests.fs
@@ -104,8 +104,6 @@ type EventStorePersistenceTests () =
 
         Assert.IsTrue(employees.Count > 0)
 
-        for persistenceId in employees do
-
         let emps = List.ofSeq(employees)
         let isEmpString (x:string) = x.Contains("all-employees")
 

--- a/CurryOn.Tests/EventStorePersistenceTests.fs
+++ b/CurryOn.Tests/EventStorePersistenceTests.fs
@@ -99,23 +99,20 @@ type EventStorePersistenceTests () =
         let employees = new System.Collections.Generic.List<string>()        
         
         let task = readJournal.CurrentPersistenceIds().RunForeach((fun id -> employees.Add(id)), materializer) |> Task.ofUnit |> Task.runSynchronously
-        //let task = readJournal.CurrentEventsByTag("all-employees", Offset.NoOffset()).RunForeach((fun id -> employees.Add(id.PersistenceId)), materializer) |> Task.ofUnit |> Task.runSynchronously
 
         sleep 2
 
         Assert.IsTrue(employees.Count > 0)
 
-<<<<<<< HEAD
-
         for persistenceId in employees do
-=======
+
         let emps = List.ofSeq(employees)
         let isEmpString (x:string) = x.Contains("all-employees")
 
         let filteredEmps = List.filter isEmpString emps
 
         for persistenceId in filteredEmps do
->>>>>>> update_to_1_3_8
+
             let events = new System.Collections.Generic.List<EventEnvelope>()
             readJournal.CurrentEventsByPersistenceId(persistenceId, 0L, 4095L).RunForeach((fun event -> events.Add(event)), materializer) |> Task.ofUnit |> Task.runSynchronously
             Assert.IsTrue(events.Count > 0)

--- a/CurryOn.Tests/EventStorePersistenceTests.fs
+++ b/CurryOn.Tests/EventStorePersistenceTests.fs
@@ -30,7 +30,7 @@ type EventStorePersistenceTests () =
                 plugin = "akka.persistence.journal.event-store"
                 event-store {
                     class = "Akka.Persistence.EventStore.EventStoreJournal, CurryOn.Akka.Persistence.EventStore"
-                    server-name = "corpweiapd001"
+                    server-name = "localhost"
                     write-batch-size = 4095
                     read-batch-size = 4095
                 }
@@ -39,7 +39,7 @@ type EventStorePersistenceTests () =
                 plugin = "akka.persistence.snapshot-store.event-store"
                 event-store {
                     class = "Akka.Persistence.EventStore.EventStoreSnapshotStore, CurryOn.Akka.Persistence.EventStore"
-                    server-name = "corpweiapd001"
+                    server-name = "localhost"
                     read-batch-size = 4095
                 }
               }
@@ -47,7 +47,7 @@ type EventStorePersistenceTests () =
                 journal {
                   event-store {
                     class = "Akka.Persistence.EventStore.EventStoreReadJournalProvider, CurryOn.Akka.Persistence.EventStore"
-                    server-name = "corpweiapd001"
+                    server-name = "localhost"
                     read-batch-size = 4095
                   }
                 }  
@@ -103,6 +103,7 @@ type EventStorePersistenceTests () =
         sleep 2
 
         Assert.IsTrue(employees.Count > 0)
+
 
         for persistenceId in employees do
             let events = new System.Collections.Generic.List<EventEnvelope>()

--- a/CurryOn.Tests/EventStorePersistenceTests.fs
+++ b/CurryOn.Tests/EventStorePersistenceTests.fs
@@ -99,13 +99,23 @@ type EventStorePersistenceTests () =
         let employees = new System.Collections.Generic.List<string>()        
         
         let task = readJournal.CurrentPersistenceIds().RunForeach((fun id -> employees.Add(id)), materializer) |> Task.ofUnit |> Task.runSynchronously
+        //let task = readJournal.CurrentEventsByTag("all-employees", Offset.NoOffset()).RunForeach((fun id -> employees.Add(id.PersistenceId)), materializer) |> Task.ofUnit |> Task.runSynchronously
 
         sleep 2
 
         Assert.IsTrue(employees.Count > 0)
 
+<<<<<<< HEAD
 
         for persistenceId in employees do
+=======
+        let emps = List.ofSeq(employees)
+        let isEmpString (x:string) = x.Contains("all-employees")
+
+        let filteredEmps = List.filter isEmpString emps
+
+        for persistenceId in filteredEmps do
+>>>>>>> update_to_1_3_8
             let events = new System.Collections.Generic.List<EventEnvelope>()
-            readJournal.CurrentEventsByPersistenceId(persistenceId, 0L, Int64.MaxValue).RunForeach((fun event -> events.Add(event)), materializer) |> Task.ofUnit |> Task.runSynchronously
+            readJournal.CurrentEventsByPersistenceId(persistenceId, 0L, 4095L).RunForeach((fun event -> events.Add(event)), materializer) |> Task.ofUnit |> Task.runSynchronously
             Assert.IsTrue(events.Count > 0)

--- a/CurryOn.Tests/packages.config
+++ b/CurryOn.Tests/packages.config
@@ -1,28 +1,29 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Akka" version="1.2.3" targetFramework="net46" />
-  <package id="Akka.FSharp" version="1.2.3" targetFramework="net46" />
-  <package id="Akka.Persistence" version="1.2.3.43-beta" targetFramework="net46" />
-  <package id="Akka.Persistence.FSharp" version="1.2.3.43-beta" targetFramework="net46" />
-  <package id="Akka.Persistence.Query" version="1.2.3.43-beta" targetFramework="net46" />
-  <package id="Akka.Persistence.Query.Sql" version="1.2.3.43-beta" targetFramework="net46" />
-  <package id="Akka.Persistence.Sql.Common" version="1.2.3.43-beta" targetFramework="net46" />
-  <package id="Akka.Persistence.SqlServer" version="1.1.1.7-beta" targetFramework="net46" />
-  <package id="Akka.Serialization.Hyperion" version="1.2.3.43-beta" targetFramework="net46" />
-  <package id="Akka.Streams" version="1.2.3" targetFramework="net46" />
-  <package id="Akka.TestKit" version="1.2.3" targetFramework="net46" />
+  <package id="Akka" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.FSharp" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.Persistence" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.Persistence.FSharp" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.Persistence.Query" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.Persistence.Query.Sql" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.Persistence.Sql.Common" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.Persistence.SqlServer" version="1.3.7" targetFramework="net46" />
+  <package id="Akka.Serialization.Hyperion" version="1.3.8-beta66" targetFramework="net46" />
+  <package id="Akka.Streams" version="1.3.8" targetFramework="net46" />
+  <package id="Akka.TestKit" version="1.3.8" targetFramework="net46" />
   <package id="Elasticsearch.Net" version="5.6.0" targetFramework="net46" />
   <package id="EventStore.Client" version="4.0.3" targetFramework="net46" />
-  <package id="FSharp.Core" version="4.1.17" targetFramework="net46" />
-  <package id="FsPickler" version="3.2.0" targetFramework="net46" />
+  <package id="FSharp.Core" version="4.2.3" targetFramework="net46" />
+  <package id="FSharp.Quotations.Evaluator" version="1.1.2" targetFramework="net46" />
+  <package id="FsPickler" version="5.2" targetFramework="net46" />
   <package id="FSPowerPack.Core.Community" version="3.0.0.0" targetFramework="net46" />
   <package id="FSPowerPack.Linq.Community" version="3.0.0.0" targetFramework="net46" />
   <package id="Google.Protobuf" version="3.3.0" targetFramework="net46" />
   <package id="Google.ProtocolBuffers" version="2.4.1.555" targetFramework="net46" />
-  <package id="Hyperion" version="0.9.2" targetFramework="net46" />
+  <package id="Hyperion" version="0.9.8" targetFramework="net46" />
   <package id="NEST" version="5.6.0" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="10.0.1" targetFramework="net46" />
   <package id="Reactive.Streams" version="1.0.2" targetFramework="net46" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net46" />
-  <package id="System.ValueTuple" version="4.3.0" targetFramework="net46" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net46" />
 </packages>

--- a/nugetpack.bat
+++ b/nugetpack.bat
@@ -1,0 +1,11 @@
+@ECHO OFF
+SETLOCAL
+SET VERSION=%1
+SET NUGET=nuget.exe
+
+FOR /r %%f IN (*.nuspec) DO (
+  echo "packing..."
+  %NUGET% pack %%f -IncludeReferencedProjects
+)
+
+PAUSE


### PR DESCRIPTION
Changed References to Akka 1.3.8
This also updated FsPickler to 5.2

Marked JsonSerializer with omitHeader = true to avoid future versioning issues due to FsPickler header info in serialized objects. In some cases, the header is still included which needs to be resolved. Events serialized in prior versions may not be compatible.

Modified Hocon configurations to point to localhost.

Modified the Eventstore WriteJournal's GetEvents function to use the readBatchSize value instead of passed in "max" value (often Int64.MaxValue) which was causing a "Count must be positive" exception in the Eventstore client. This could also be handled by the caller which I did in the TestEventStoreReadJournal unit test. But, this approach ensures that the count sent to Eventstore client is no larger than the configured value.

Removed unneeded reference in Tests project


