### PR TITLE
Fix type-casting bug in Result.ofException

### DIFF
--- a/CurryOn.FSharp.Control/Operation.fs
+++ b/CurryOn.FSharp.Control/Operation.fs
@@ -99,7 +99,7 @@ module Result =
         | ex -> 
             let union = FSharpType.GetUnionCases(typeof<OperationResult<'result, 'event>>)
             if typeof<'event>.IsAssignableFrom(typeof<exn>)
-            then FSharpValue.MakeUnion(union.[1], [|[ex] |> box|]) |> unbox<OperationResult<'result, 'event>>
+            then FSharpValue.MakeUnion(union.[1], [|[ex |> box :?> 'event] |> box|]) |> unbox<OperationResult<'result, 'event>>
             elif FSharpType.IsUnion typeof<'event>
             then let cases = FSharpType.GetUnionCases(typeof<'event>)
                  match cases |> Seq.tryFind (fun case -> case.Fields.Length = 1 && case.Fields.[0].PropertyType.IsAssignableFrom(typeof<exn>)) with


### PR DESCRIPTION
I encountered this bug when an `Operation` used `ofException` under the hood and threw an exception in `MakeUnion` about being unable to cast from `Exception list` to `object list`.  The fix is to do the casting at the `'event` level instead of at the `'event list` level.